### PR TITLE
ci: source credentials from SSM via OIDC (rubygems + slack + qlty)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pull-requests: write
   checks: read
+  id-token: write
 
 jobs:
   auto-merge:
@@ -155,15 +156,25 @@ jobs:
     needs: auto-merge
     if: always() && github.actor == 'dependabot[bot]'
     steps:
+      - name: Fetch Slack credentials from SSM (OIDC)
+        if: needs.auto-merge.result == 'success' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        with:
+          role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          params: |
+            /providers/messaging/slack/main/bot-token   SLACK_BOT_TOKEN
+            /providers/messaging/slack/main/channel-id  SLACK_CHANNEL_ID
+
       - name: Notify Slack about auto-merge
         if: needs.auto-merge.result == 'success' && github.event.pull_request.head.repo.full_name == github.repository
         uses: slackapi/slack-github-action@v3.0.3
         with:
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          token: ${{ env.SLACK_BOT_TOKEN }}
           method: chat.postMessage
           payload: |
             {
-              "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
+              "channel": "${{ env.SLACK_CHANNEL_ID }}",
               "text": "🤖 Auto-merged: ${{ github.event.pull_request.title }}",
               "username": "dbwatcher",
               "icon_emoji": ":mag:",

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -24,13 +24,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Generate dbwatcher-ci App Token
+      - name: Fetch p204-helm App credentials from SSM (OIDC)
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: patrick204nqh/aws-ssm-fetch-action@v1
+        with:
+          role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          params: |
+            /providers/app/p204-helm/main/app-id        APP_ID
+            /providers/app/p204-helm/main/private-key   PRIVATE_KEY
+
+      - name: Generate App Token
         if: github.event.pull_request.head.repo.full_name == github.repository
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.DBWATCHER_CI_APP_ID }}
-          private-key: ${{ secrets.DBWATCHER_CI_PRIVATE_KEY }}
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
 
       - name: Check if PR is ready for auto-merge
         id: check

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - name: Fetch Slack credentials from SSM (OIDC)
         if: needs.auto-merge.result == 'success' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        uses: patrick204nqh/aws-ssm-fetch-action@v1
         with:
           role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,13 +145,23 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v6
 
-      - name: Generate dbwatcher-ci App Token
+      - name: Fetch p204-helm App credentials from SSM (OIDC)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: patrick204nqh/aws-ssm-fetch-action@v1
+        with:
+          role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          params: |
+            /providers/app/p204-helm/main/app-id        APP_ID
+            /providers/app/p204-helm/main/private-key   PRIVATE_KEY
+
+      - name: Generate App Token
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.DBWATCHER_CI_APP_ID }}
-          private-key: ${{ secrets.DBWATCHER_CI_PRIVATE_KEY }}
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
 
       - name: Determine CI status
         id: ci_status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Fetch Qlty token from SSM (OIDC)
         if: success() && github.ref == 'refs/heads/master'
-        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        uses: patrick204nqh/aws-ssm-fetch-action@v1
         with:
           role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -207,7 +207,7 @@ jobs:
 
       - name: Fetch Slack credentials from SSM (OIDC)
         if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
-        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        uses: patrick204nqh/aws-ssm-fetch-action@v1
         with:
           role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,20 @@ jobs:
       - name: Run Cucumber acceptance tests
         run: bundle exec rake acceptance
 
+      - name: Fetch Qlty token from SSM (OIDC)
+        if: success() && github.ref == 'refs/heads/master'
+        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        with:
+          role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          params: |
+            /providers/coverage/qlty/main/token   QLTY_COVERAGE_TOKEN
+
       - name: Upload coverage to Qlty
         if: success() && github.ref == 'refs/heads/master'
         uses: qltysh/qlty-action/coverage@v2
         with:
-          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          token: ${{ env.QLTY_COVERAGE_TOKEN }}
           files: coverage/.resultset.json
 
       - name: Upload coverage artifacts
@@ -196,15 +205,25 @@ jobs:
           # Post comment
           gh pr comment ${{ github.event.pull_request.number }} --body-file pr_report.md
 
+      - name: Fetch Slack credentials from SSM (OIDC)
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        with:
+          role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          params: |
+            /providers/messaging/slack/main/bot-token   SLACK_BOT_TOKEN
+            /providers/messaging/slack/main/channel-id  SLACK_CHANNEL_ID
+
       - name: Notify Slack
         if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
         uses: slackapi/slack-github-action@v3.0.3
         with:
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          token: ${{ env.SLACK_BOT_TOKEN }}
           method: chat.postMessage
           payload: |
             {
-              "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
+              "channel": "${{ env.SLACK_CHANNEL_ID }}",
               "text": "${{ steps.ci_status.outputs.emoji }} CI ${{ steps.ci_status.outputs.status }} - ${{ github.ref_name }}",
               "blocks": [
                 {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,13 +220,22 @@ jobs:
           echo "Would publish: ${{ steps.build.outputs.gem_file }}"
           exit 0
 
+      - name: Fetch RubyGems credentials from SSM (OIDC)
+        if: needs.validate-release.outputs.is_dry_run != 'true'
+        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        with:
+          role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          params: |
+            /providers/package-registry/rubygems/main/api-key   RUBYGEMS_API_KEY
+
       - name: Setup RubyGems credentials
         if: needs.validate-release.outputs.is_dry_run != 'true'
         run: |
           mkdir -p ~/.gem
           cat > ~/.gem/credentials << EOF
           ---
-          :rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}
+          :rubygems_api_key: ${{ env.RUBYGEMS_API_KEY }}
           EOF
           chmod 0600 ~/.gem/credentials
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
 
       - name: Fetch RubyGems credentials from SSM (OIDC)
         if: needs.validate-release.outputs.is_dry_run != 'true'
-        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        uses: patrick204nqh/aws-ssm-fetch-action@v1
         with:
           role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -301,7 +301,7 @@ jobs:
     if: needs.validate-release.outputs.should_release == 'true' && needs.validate-release.outputs.is_dry_run != 'true'
     steps:
       - name: Fetch Slack credentials from SSM (OIDC)
-        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        uses: patrick204nqh/aws-ssm-fetch-action@v1
         with:
           role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -384,7 +384,7 @@ jobs:
     if: always() && (failure() || cancelled()) && needs.validate-release.outputs.should_release == 'true'
     steps:
       - name: Fetch Slack credentials from SSM (OIDC)
-        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        uses: patrick204nqh/aws-ssm-fetch-action@v1
         with:
           role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,8 +297,18 @@ jobs:
     needs: [validate-release, build-and-publish]
     runs-on: ubuntu-latest
     name: Post-Release Tasks
+    environment: production
     if: needs.validate-release.outputs.should_release == 'true' && needs.validate-release.outputs.is_dry_run != 'true'
     steps:
+      - name: Fetch Slack credentials from SSM (OIDC)
+        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        with:
+          role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          params: |
+            /providers/messaging/slack/main/bot-token   SLACK_BOT_TOKEN
+            /providers/messaging/slack/main/channel-id  SLACK_CHANNEL_ID
+
       - name: Verify publication
         run: |
           VERSION="${{ needs.validate-release.outputs.version }}"
@@ -325,11 +335,11 @@ jobs:
         if: success()
         uses: slackapi/slack-github-action@v3.0.3
         with:
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          token: ${{ env.SLACK_BOT_TOKEN }}
           method: chat.postMessage
           payload: |
             {
-              "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
+              "channel": "${{ env.SLACK_CHANNEL_ID }}",
               "text": "🚀 Released v${{ needs.validate-release.outputs.version }}",
               "blocks": [
                 {
@@ -370,8 +380,18 @@ jobs:
     needs: [validate-release, build-and-publish, post-release]
     runs-on: ubuntu-latest
     name: Notify on Failure
+    environment: production
     if: always() && (failure() || cancelled()) && needs.validate-release.outputs.should_release == 'true'
     steps:
+      - name: Fetch Slack credentials from SSM (OIDC)
+        uses: patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main
+        with:
+          role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          params: |
+            /providers/messaging/slack/main/bot-token   SLACK_BOT_TOKEN
+            /providers/messaging/slack/main/channel-id  SLACK_CHANNEL_ID
+
       - name: Determine failed job
         id: failed_job
         run: |
@@ -392,11 +412,11 @@ jobs:
       - name: Notify Slack - Release Failure
         uses: slackapi/slack-github-action@v3.0.3
         with:
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          token: ${{ env.SLACK_BOT_TOKEN }}
           method: chat.postMessage
           payload: |
             {
-              "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
+              "channel": "${{ env.SLACK_CHANNEL_ID }}",
               "text": "❌ Release failed v${{ needs.validate-release.outputs.version || 'Unknown' }}",
               "blocks": [
                 {


### PR DESCRIPTION
Migrates all catalog-managed secret references to OIDC-assumed reads via the `patrick204nqh/infrastructure/.github/actions/aws-ssm-fetch@main` composite action.

## Changes
- **release.yml** `build-and-publish`: rubygems via SSM (env=production already set)
- **release.yml** `post-release` + `notify-failure`: env=production added; slack via SSM
- **ci.yml** `test` job: qlty token via SSM (master-only condition preserved)
- **ci.yml** `notify` job: slack via SSM
- **auto-merge.yml** `notify-auto-merge` job: slack via SSM; `id-token: write` added to top-level permissions

## Pre-reqs (in infrastructure repo)
1. `pulumi up --stack bootstrap` — creates the `github-actions-dbwatcher` IAM role with sub patterns: `environment:production`, `ref:refs/heads/main`, `ref:refs/heads/master`, `pull_request` (for slack only; qlty is master-only).
2. `pulumi up --stack prod` on `stacks/github` — publishes `AWS_ROLE_ARN` + `AWS_REGION` ActionsVariables.
3. infrastructure PR merged to main so `@main` resolves to a ref with the composite action.

## Untouched
- `secrets.DBWATCHER_CI_APP_ID` / `secrets.DBWATCHER_CI_PRIVATE_KEY` — separate GitHub App not in the @infra/catalog scope. To be migrated in a Phase 7 follow-up.