### PR TITLE
ci: rename qlty SSM path main → dbwatcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           params: |
-            /providers/coverage/qlty/main/token   QLTY_COVERAGE_TOKEN
+            /providers/coverage/qlty/dbwatcher/token   QLTY_COVERAGE_TOKEN
 
       - name: Upload coverage to Qlty
         if: success() && github.ref == 'refs/heads/master'


### PR DESCRIPTION
Catalog refactored qlty into per-project accounts (patrick204nqh/infrastructure#TBD). dbwatcher's Qlty token now lives at `/providers/coverage/qlty/dbwatcher/token` instead of `…/qlty/main/token`.

## Merge order
Merge this **after** the infra catalog PR has been merged AND the SSM param has been provisioned at the new path (otherwise this CI step still fails with ParameterNotFound).